### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,10 @@
 [![Build Status](https://travis-ci.org/seanh/flitter.svg)](https://travis-ci.org/seanh/flitter)
 [![Coverage Status](https://img.shields.io/coveralls/seanh/flitter.svg)](https://coveralls.io/r/seanh/flitter)
-[![Latest Version](https://pypip.in/version/flitter/badge.svg)](https://pypi.python.org/pypi/flitter/)
-[![Downloads](https://pypip.in/download/flitter/badge.svg)](https://pypi.python.org/pypi/flitter/)
-[![Supported Python versions](https://pypip.in/py_versions/flitter/badge.svg)](https://pypi.python.org/pypi/flitter/)
-[![Development Status](https://pypip.in/status/flitter/badge.svg)](https://pypi.python.org/pypi/flitter/)
-[![License](https://pypip.in/license/flitter/badge.svg)](https://pypi.python.org/pypi/flitter/)
+[![Latest Version](https://img.shields.io/pypi/v/flitter.svg)](https://pypi.python.org/pypi/flitter/)
+[![Downloads](https://img.shields.io/pypi/dm/flitter.svg)](https://pypi.python.org/pypi/flitter/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/flitter.svg)](https://pypi.python.org/pypi/flitter/)
+[![Development Status](https://img.shields.io/pypi/status/flitter.svg)](https://pypi.python.org/pypi/flitter/)
+[![License](https://img.shields.io/pypi/l/flitter.svg)](https://pypi.python.org/pypi/flitter/)
 
 
 Flitter


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flitter))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flitter`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.